### PR TITLE
Adding __contains__ to the WhatsappMessage

### DIFF
--- a/src/wamd/messages.py
+++ b/src/wamd/messages.py
@@ -46,6 +46,9 @@ class WhatsAppMessage:
         for k, v in kwargs.items():
             self._attrs[k] = v
 
+    def __contains__(self, item):
+        return item in self._attrs
+
     def __getitem__(self, item):
         try:
             return self._attrs[item]


### PR DESCRIPTION
That allows to check for membership of message properties using the 'in' keyword.

Example, current main:
```python
m = WhatsAppMessage()
# this line halts, read the docs of __contains__
# https://docs.python.org/3/reference/datamodel.html#object.__contains__
'mime' in m
```
With this fix:
```python
>>> 'mime' in m
False
>>> 'id' in m
True
```